### PR TITLE
fix crash on ios13 trying to access the "_searchField" value for key

### DIFF
--- a/DKNightVersion/Manual/UISearchBar+Keyboard.m
+++ b/DKNightVersion/Manual/UISearchBar+Keyboard.m
@@ -50,15 +50,21 @@
 - (instancetype)dk_init {
     UISearchBar *obj = [self dk_init];
     if (self.dk_manager.supportsKeyboard && [self.dk_manager.themeVersion isEqualToString:DKThemeVersionNight]) {
-
-#ifdef __IPHONE_7_0
+        
+#if defined(__IPHONE_13_0)
+        UISearchTextField *searchField = obj.searchTextField;
+        searchField.keyboardAppearance = UIKeyboardAppearanceDark;
+#elif defined(__IPHONE_7_0)
         UITextField *searchField = [obj valueForKey:@"_searchField"];
         searchField.keyboardAppearance = UIKeyboardAppearanceDark;
 #else
         obj.keyboardAppearance = UIKeyboardAppearanceAlert;
 #endif
     } else {
-#ifdef __IPHONE_7_0
+#if defined(__IPHONE_13_0)
+        UISearchTextField *searchField = obj.searchTextField;
+        searchField.keyboardAppearance = UIKeyboardAppearanceDefault;
+#elif defined(__IPHONE_7_0)
         UITextField *searchField = [obj valueForKey:@"_searchField"];
         searchField.keyboardAppearance = UIKeyboardAppearanceDefault;
 #else
@@ -72,14 +78,20 @@
 - (void)night_updateColor {
     [super night_updateColor];
     if (self.dk_manager.supportsKeyboard && [self.dk_manager.themeVersion isEqualToString:DKThemeVersionNight]) {
-#ifdef __IPHONE_7_0
+#if defined(__IPHONE_13_0)
+        UISearchTextField *searchField = self.searchTextField;
+        searchField.keyboardAppearance = UIKeyboardAppearanceDark;
+#elif defined(__IPHONE_7_0)
         UITextField *searchField = [self valueForKey:@"_searchField"];
         searchField.keyboardAppearance = UIKeyboardAppearanceDark;
 #else
         self.keyboardAppearance = UIKeyboardAppearanceAlert;
 #endif
     } else {
-#ifdef __IPHONE_7_0
+#if defined(__IPHONE_13_0)
+        UISearchTextField *searchField = self.searchTextField;
+        searchField.keyboardAppearance = UIKeyboardAppearanceDefault;
+#elif defined(__IPHONE_7_0)
         UITextField *searchField = [self valueForKey:@"_searchField"];
         searchField.keyboardAppearance = UIKeyboardAppearanceDefault;
 #else


### PR DESCRIPTION
From iOS13 accessing _searchField ivar is prohibited.

Here is the stacktrace:

```
2019-07-11 14:40:34.704139+0200 DemoApp[24226:220295] *** Terminating app due to uncaught exception 'NSGenericException', reason: 'Access to UISearchBar's _searchField ivar is prohibited. This is an application bug'
*** First throw call stack:
(
	0   CoreFoundation                      0x00007fff23af9c3e __exceptionPreprocess + 350
	1   libobjc.A.dylib                     0x00007fff50131de0 objc_exception_throw + 48
	2   CoreFoundation                      0x00007fff23af9a7c +[NSException raise:format:] + 188
	3   UIKitCore                           0x00007fff46381a3e -[UISearchBar _searchField] + 49
	4   Foundation                          0x00007fff2559d97f -[NSObject(NSKeyValueCoding) valueForKey:] + 317
	5   DKNightVersion                      0x000000011118b2b9 -[UISearchBar(Keyboard) dk_init] + 441
.
.
.
```